### PR TITLE
Read multiple calibration types

### DIFF
--- a/vtr_storage/include/vtr_storage/data_stream_reader.hpp
+++ b/vtr_storage/include/vtr_storage/data_stream_reader.hpp
@@ -23,11 +23,10 @@ class DataStreamReaderBase : public DataStreamBase {
 
   // returns a nullptr if no data exist at the specified index/timestamp
   std::shared_ptr<VTRMessage> readAtIndex(int32_t index);
-  std::shared_ptr<VTRMessage> readAtTimestamp(
-      rcutils_time_point_value_t time);
+  std::shared_ptr<VTRMessage> readAtTimestamp(rcutils_time_point_value_t time);
   // returns an empty vector if no data exist at the specified range
-  std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>>
-  readAtIndexRange(int32_t index_begin, int32_t index_end);
+  std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>> readAtIndexRange(
+      int32_t index_begin, int32_t index_end);
   std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>>
   readAtTimestampRange(rcutils_time_point_value_t time_begin,
                        rcutils_time_point_value_t time_end);
@@ -35,7 +34,7 @@ class DataStreamReaderBase : public DataStreamBase {
   bool seekByIndex(int32_t index);
   bool seekByTimestamp(rcutils_time_point_value_t timestamp);
   std::shared_ptr<VTRMessage> readNextFromSeek();
- 
+
  protected:
   virtual std::shared_ptr<VTRMessage> convertBagMessage(
       std::shared_ptr<rosbag2_storage::SerializedBagMessage> bag_message) = 0;
@@ -47,11 +46,12 @@ template <typename MessageType>
 class DataStreamReaderMoreSpecificBase : public DataStreamReaderBase {
  public:
   DataStreamReaderMoreSpecificBase(const std::string &data_directory,
-                   const std::string &stream_name = "");
+                                   const std::string &stream_name = "");
 
  protected:
   std::shared_ptr<VTRMessage> convertBagMessage(
-      std::shared_ptr<rosbag2_storage::SerializedBagMessage> bag_message) override;
+      std::shared_ptr<rosbag2_storage::SerializedBagMessage> bag_message)
+      override;
 
   rclcpp::Serialization<MessageType> serialization_;
 };
@@ -61,27 +61,31 @@ class DataStreamReader : public DataStreamReaderMoreSpecificBase<MessageType> {
  public:
   DataStreamReader(const std::string &data_directory,
                    const std::string &stream_name = "")
-                   : DataStreamReaderMoreSpecificBase<MessageType>(data_directory, stream_name) {}
-  
+      : DataStreamReaderMoreSpecificBase<MessageType>(data_directory,
+                                                      stream_name) {}
+
   std::shared_ptr<VTRMessage> fetchCalibration() override;
 
  protected:
-  rclcpp::Serialization<CalibrationType>
-      calibration_serialization_;
+  rclcpp::Serialization<CalibrationType> calibration_serialization_;
   std::shared_ptr<RandomAccessReader> calibration_reader_;
   bool calibration_fetched_ = false;
   std::shared_ptr<VTRMessage> calibration_msg_;
 };
 
 template <typename MessageType>
-class DataStreamReader<MessageType, NoCalibration> : public DataStreamReaderMoreSpecificBase<MessageType> {
+class DataStreamReader<MessageType, NoCalibration>
+    : public DataStreamReaderMoreSpecificBase<MessageType> {
  public:
   DataStreamReader(const std::string &data_directory,
                    const std::string &stream_name = "")
-                   : DataStreamReaderMoreSpecificBase<MessageType>(data_directory, stream_name) {}
+      : DataStreamReaderMoreSpecificBase<MessageType>(data_directory,
+                                                      stream_name) {}
 
   std::shared_ptr<VTRMessage> fetchCalibration() override {
-    assert(false && "Attempted to fetchCalibration() calibration for NoCalibration type!");
+    assert(
+        false &&
+        "Attempted to fetchCalibration() calibration for NoCalibration type!");
     return nullptr;  // for suppressing warnings
   }
 };

--- a/vtr_storage/include/vtr_storage/data_stream_reader.hpp
+++ b/vtr_storage/include/vtr_storage/data_stream_reader.hpp
@@ -14,24 +14,59 @@ class DataStreamReaderBase : public DataStreamBase {
   DataStreamReaderBase(const std::string &data_directory,
                        const std::string &stream_name = "")
       : DataStreamBase(data_directory, stream_name) {}
-  virtual ~DataStreamReaderBase() {}
+  virtual ~DataStreamReaderBase();
 
-  virtual void openAndGetMessageType() = 0;
-  virtual void close() = 0;
+  void openAndGetMessageType();
+  void close();
 
-  virtual std::shared_ptr<VTRMessage> readAtIndex(int32_t index) = 0;
-  virtual std::shared_ptr<VTRMessage> readAtTimestamp(
-      rcutils_time_point_value_t time) = 0;
-  virtual std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>>
-  readAtIndexRange(int32_t index_begin, int32_t index_end) = 0;
-  virtual std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>>
+  virtual std::shared_ptr<VTRMessage> fetchCalibration() = 0;
+
+  // returns a nullptr if no data exist at the specified index/timestamp
+  std::shared_ptr<VTRMessage> readAtIndex(int32_t index);
+  std::shared_ptr<VTRMessage> readAtTimestamp(
+      rcutils_time_point_value_t time);
+  // returns an empty vector if no data exist at the specified range
+  std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>>
+  readAtIndexRange(int32_t index_begin, int32_t index_end);
+  std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>>
   readAtTimestampRange(rcutils_time_point_value_t time_begin,
-                       rcutils_time_point_value_t time_end) = 0;
+                       rcutils_time_point_value_t time_end);
 
-  std::shared_ptr<VTRMessage> fetchCalibration();
+  bool seekByIndex(int32_t index);
+  bool seekByTimestamp(rcutils_time_point_value_t timestamp);
+  std::shared_ptr<VTRMessage> readNextFromSeek();
+ 
+ protected:
+  virtual std::shared_ptr<VTRMessage> convertBagMessage(
+      std::shared_ptr<rosbag2_storage::SerializedBagMessage> bag_message) = 0;
+  std::shared_ptr<RandomAccessReader> reader_;
+  bool seeked_ = false;
+};
+
+template <typename MessageType>
+class DataStreamReaderMoreSpecificBase : public DataStreamReaderBase {
+ public:
+  DataStreamReaderMoreSpecificBase(const std::string &data_directory,
+                   const std::string &stream_name = "");
 
  protected:
-  rclcpp::Serialization<vtr_messages::msg::RigCalibration>
+  std::shared_ptr<VTRMessage> convertBagMessage(
+      std::shared_ptr<rosbag2_storage::SerializedBagMessage> bag_message) override;
+
+  rclcpp::Serialization<MessageType> serialization_;
+};
+
+template <typename MessageType, typename CalibrationType = NoCalibration>
+class DataStreamReader : public DataStreamReaderMoreSpecificBase<MessageType> {
+ public:
+  DataStreamReader(const std::string &data_directory,
+                   const std::string &stream_name = "")
+                   : DataStreamReaderMoreSpecificBase<MessageType>(data_directory, stream_name) {}
+  
+  std::shared_ptr<VTRMessage> fetchCalibration() override;
+
+ protected:
+  rclcpp::Serialization<CalibrationType>
       calibration_serialization_;
   std::shared_ptr<RandomAccessReader> calibration_reader_;
   bool calibration_fetched_ = false;
@@ -39,40 +74,17 @@ class DataStreamReaderBase : public DataStreamBase {
 };
 
 template <typename MessageType>
-class DataStreamReader : public DataStreamReaderBase {
+class DataStreamReader<MessageType, NoCalibration> : public DataStreamReaderMoreSpecificBase<MessageType> {
  public:
   DataStreamReader(const std::string &data_directory,
-                   const std::string &stream_name = "");
-  ~DataStreamReader();
+                   const std::string &stream_name = "")
+                   : DataStreamReaderMoreSpecificBase<MessageType>(data_directory, stream_name) {}
 
-  void openAndGetMessageType() override;
-  void close() override;
-
-  // returns a nullptr if no data exist at the specified index/timestamp
-  std::shared_ptr<VTRMessage> readAtIndex(int32_t index) override;
-  std::shared_ptr<VTRMessage> readAtTimestamp(
-      rcutils_time_point_value_t time) override;
-
-  // returns an empty vector if no data exist at the specified range
-  std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>> readAtIndexRange(
-      int32_t index_begin, int32_t index_end) override;
-  std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>>
-  readAtTimestampRange(rcutils_time_point_value_t time_begin,
-                       rcutils_time_point_value_t time_end) override;
-
-  bool seekByIndex(int32_t index);
-  bool seekByTimestamp(rcutils_time_point_value_t timestamp);
-  std::shared_ptr<VTRMessage> readNextFromSeek();
-
- protected:
-  std::shared_ptr<VTRMessage> convertBagMessage(
-      std::shared_ptr<rosbag2_storage::SerializedBagMessage> bag_message);
-
-  rclcpp::Serialization<MessageType> serialization_;
-  std::shared_ptr<RandomAccessReader> reader_;
-  bool seeked_ = false;
+  std::shared_ptr<VTRMessage> fetchCalibration() override {
+    assert(false && "Attempted to fetchCalibration() calibration for NoCalibration type!");
+    return nullptr;  // for suppressing warnings
+  }
 };
-
 }  // namespace storage
 }  // namespace vtr
 

--- a/vtr_storage/include/vtr_storage/data_stream_reader.inl
+++ b/vtr_storage/include/vtr_storage/data_stream_reader.inl
@@ -6,38 +6,13 @@ namespace vtr {
 namespace storage {
 
 template <typename MessageType>
-DataStreamReader<MessageType>::DataStreamReader(
+DataStreamReaderMoreSpecificBase<MessageType>::DataStreamReaderMoreSpecificBase(
     const std::string &data_directory, const std::string &stream_name)
     : DataStreamReaderBase(data_directory, stream_name) {}
 
-template <typename MessageType>
-DataStreamReader<MessageType>::~DataStreamReader() {
-  close();
-}
 
 template <typename MessageType>
-void DataStreamReader<MessageType>::close() {
-  reader_.reset();
-  this->opened_ = false;
-  seeked_ = false;
-}
-
-template <typename MessageType>
-void DataStreamReader<MessageType>::openAndGetMessageType() {
-  if (this->opened_ == false) {
-    if (!data_directory_.exists()) {
-      throw NoBagExistsException(data_directory_);
-    }
-    reader_ = std::make_shared<RandomAccessReader>(this->stream_name_);
-    reader_->open(this->storage_options_, this->converter_options_);
-    this->opened_ = true;
-  }
-  // ToDo: get message type, specialize this->serialization_ based on message
-  // type?
-}
-
-template <typename MessageType>
-std::shared_ptr<VTRMessage> DataStreamReader<MessageType>::convertBagMessage(
+std::shared_ptr<VTRMessage> DataStreamReaderMoreSpecificBase<MessageType>::convertBagMessage(
     std::shared_ptr<rosbag2_storage::SerializedBagMessage> bag_message) {
   std::shared_ptr<VTRMessage> anytype_msg;
   if (bag_message) {
@@ -57,81 +32,47 @@ std::shared_ptr<VTRMessage> DataStreamReader<MessageType>::convertBagMessage(
   return anytype_msg;
 }
 
-template <typename MessageType>
-std::shared_ptr<VTRMessage> DataStreamReader<MessageType>::readAtIndex(
-    int32_t index) {
-  openAndGetMessageType();
-  auto bag_message = reader_->read_at_index(index);
-  return convertBagMessage(bag_message);
-}
 
-template <typename MessageType>
-std::shared_ptr<VTRMessage> DataStreamReader<MessageType>::readAtTimestamp(
-    rcutils_time_point_value_t time) {
-  openAndGetMessageType();
-  auto bag_message = reader_->read_at_timestamp(time);
-  return convertBagMessage(bag_message);
-}
+template <typename MessageType, typename CalibrationType>
+std::shared_ptr<VTRMessage>
+DataStreamReader<MessageType,CalibrationType>::fetchCalibration() {
+  if (!calibration_fetched_) {
+    if (!(this->base_directory_/CALIBRATION_FOLDER).exists()) {
+      throw NoBagExistsException(this->base_directory_/CALIBRATION_FOLDER);
+    }
+    calibration_reader_ =
+        std::make_shared<RandomAccessReader>(CALIBRATION_FOLDER);
 
-template <typename MessageType>
-std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>>
-DataStreamReader<MessageType>::readAtIndexRange(int32_t index_begin,
-                                                int32_t index_end) {
-  openAndGetMessageType();
-  auto bag_message_vector =
-      reader_->read_at_index_range(index_begin, index_end);
-  auto deserialized_bag_message_vector =
-      std::make_shared<std::vector<std::shared_ptr<VTRMessage>>>();
-  for (auto bag_message : *bag_message_vector) {
-    auto anytype_msg = convertBagMessage(bag_message);
-    deserialized_bag_message_vector->push_back(
-        anytype_msg);  // ToDo: reserve the vector instead of pushing
-                       // back
+    rosbag2_cpp::StorageOptions calibration_storage_options = this->storage_options_;
+    calibration_storage_options.uri =
+        (this->base_directory_ / CALIBRATION_FOLDER).string();
+    calibration_reader_->open(calibration_storage_options,
+                              this->converter_options_);
+    rclcpp::Serialization<CalibrationType>
+        calibration_serialization;
+
+    auto bag_message = calibration_reader_->read_at_index(1);
+
+    if (bag_message) {
+      auto extracted_msg = std::make_shared<CalibrationType>();
+      rclcpp::SerializedMessage serialized_msg;
+      rclcpp::SerializedMessage extracted_serialized_msg(
+          *bag_message->serialized_data);
+      calibration_serialization.deserialize_message(&extracted_serialized_msg,
+                                                    extracted_msg.get());
+      calibration_fetched_ = true;
+      auto anytype_msg = std::make_shared<VTRMessage>(*extracted_msg);
+      anytype_msg->set_index(bag_message->database_index);
+      if (bag_message->time_stamp != NO_TIMESTAMP_VALUE) {
+        anytype_msg->set_timestamp(bag_message->time_stamp);
+      }
+      calibration_msg_ = anytype_msg;
+    } else {
+      throw std::runtime_error("calibration database has no messages!");
+    }
   }
-  return deserialized_bag_message_vector;
+  return calibration_msg_;
 }
 
-template <typename MessageType>
-std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>>
-DataStreamReader<MessageType>::readAtTimestampRange(
-    rcutils_time_point_value_t time_begin,
-    rcutils_time_point_value_t time_end) {
-  openAndGetMessageType();
-  auto bag_message_vector =
-      reader_->read_at_timestamp_range(time_begin, time_end);
-  auto deserialized_bag_message_vector =
-      std::make_shared<std::vector<std::shared_ptr<VTRMessage>>>();
-  for (auto bag_message : *bag_message_vector) {
-    auto anytype_msg = convertBagMessage(bag_message);
-    deserialized_bag_message_vector->push_back(
-        anytype_msg);  // ToDo: reserve the vector instead of pushing
-                       // back
-  }
-  return deserialized_bag_message_vector;
-}
-
-template <typename MessageType>
-bool DataStreamReader<MessageType>::seekByIndex(int32_t index) {
-  openAndGetMessageType();
-  seeked_ = true;
-  return reader_->seek_by_index(index);
-}
-
-template <typename MessageType>
-bool DataStreamReader<MessageType>::seekByTimestamp(
-    rcutils_time_point_value_t time) {
-  openAndGetMessageType();
-  seeked_ = true;
-  return reader_->seek_by_timestamp(time);
-}
-
-template <typename MessageType>
-std::shared_ptr<VTRMessage> DataStreamReader<MessageType>::readNextFromSeek() {
-  if (!seeked_) {
-    seekByIndex(1);  // read the whole database
-  }
-  auto bag_message = reader_->read_next_from_seek();
-  return convertBagMessage(bag_message);
-}
 }  // namespace storage
 }  // namespace vtr

--- a/vtr_storage/include/vtr_storage/data_stream_reader.inl
+++ b/vtr_storage/include/vtr_storage/data_stream_reader.inl
@@ -10,9 +10,9 @@ DataStreamReaderMoreSpecificBase<MessageType>::DataStreamReaderMoreSpecificBase(
     const std::string &data_directory, const std::string &stream_name)
     : DataStreamReaderBase(data_directory, stream_name) {}
 
-
 template <typename MessageType>
-std::shared_ptr<VTRMessage> DataStreamReaderMoreSpecificBase<MessageType>::convertBagMessage(
+std::shared_ptr<VTRMessage>
+DataStreamReaderMoreSpecificBase<MessageType>::convertBagMessage(
     std::shared_ptr<rosbag2_storage::SerializedBagMessage> bag_message) {
   std::shared_ptr<VTRMessage> anytype_msg;
   if (bag_message) {
@@ -32,24 +32,23 @@ std::shared_ptr<VTRMessage> DataStreamReaderMoreSpecificBase<MessageType>::conve
   return anytype_msg;
 }
 
-
 template <typename MessageType, typename CalibrationType>
 std::shared_ptr<VTRMessage>
-DataStreamReader<MessageType,CalibrationType>::fetchCalibration() {
+DataStreamReader<MessageType, CalibrationType>::fetchCalibration() {
   if (!calibration_fetched_) {
-    if (!(this->base_directory_/CALIBRATION_FOLDER).exists()) {
-      throw NoBagExistsException(this->base_directory_/CALIBRATION_FOLDER);
+    if (!(this->base_directory_ / CALIBRATION_FOLDER).exists()) {
+      throw NoBagExistsException(this->base_directory_ / CALIBRATION_FOLDER);
     }
     calibration_reader_ =
         std::make_shared<RandomAccessReader>(CALIBRATION_FOLDER);
 
-    rosbag2_cpp::StorageOptions calibration_storage_options = this->storage_options_;
+    rosbag2_cpp::StorageOptions calibration_storage_options =
+        this->storage_options_;
     calibration_storage_options.uri =
         (this->base_directory_ / CALIBRATION_FOLDER).string();
     calibration_reader_->open(calibration_storage_options,
                               this->converter_options_);
-    rclcpp::Serialization<CalibrationType>
-        calibration_serialization;
+    rclcpp::Serialization<CalibrationType> calibration_serialization;
 
     auto bag_message = calibration_reader_->read_at_index(1);
 

--- a/vtr_storage/include/vtr_storage/vtr_storage_common.hpp
+++ b/vtr_storage/include/vtr_storage/vtr_storage_common.hpp
@@ -15,6 +15,8 @@ namespace storage {
 
 constexpr const char CALIBRATION_FOLDER[] = "calibration";
 
+class NoCalibration{};
+
 struct NoBagExistsException : public std::runtime_error {
   NoBagExistsException(rcpputils::fs::path directory)
       : std::runtime_error(""), directory_(directory) {}

--- a/vtr_storage/include/vtr_storage/vtr_storage_common.hpp
+++ b/vtr_storage/include/vtr_storage/vtr_storage_common.hpp
@@ -15,7 +15,7 @@ namespace storage {
 
 constexpr const char CALIBRATION_FOLDER[] = "calibration";
 
-class NoCalibration{};
+class NoCalibration {};
 
 struct NoBagExistsException : public std::runtime_error {
   NoBagExistsException(rcpputils::fs::path directory)

--- a/vtr_storage/src/data_stream_reader.cpp
+++ b/vtr_storage/src/data_stream_reader.cpp
@@ -3,9 +3,7 @@
 namespace vtr {
 namespace storage {
 
-DataStreamReaderBase::~DataStreamReaderBase() {
-  close();
-}
+DataStreamReaderBase::~DataStreamReaderBase() { close(); }
 
 void DataStreamReaderBase::close() {
   reader_.reset();
@@ -26,8 +24,7 @@ void DataStreamReaderBase::openAndGetMessageType() {
   // type?
 }
 
-std::shared_ptr<VTRMessage> DataStreamReaderBase::readAtIndex(
-    int32_t index) {
+std::shared_ptr<VTRMessage> DataStreamReaderBase::readAtIndex(int32_t index) {
   openAndGetMessageType();
   auto bag_message = reader_->read_at_index(index);
   return convertBagMessage(bag_message);
@@ -41,8 +38,7 @@ std::shared_ptr<VTRMessage> DataStreamReaderBase::readAtTimestamp(
 }
 
 std::shared_ptr<std::vector<std::shared_ptr<VTRMessage>>>
-DataStreamReaderBase::readAtIndexRange(int32_t index_begin,
-                                                int32_t index_end) {
+DataStreamReaderBase::readAtIndexRange(int32_t index_begin, int32_t index_end) {
   openAndGetMessageType();
   auto bag_message_vector =
       reader_->read_at_index_range(index_begin, index_end);
@@ -81,8 +77,7 @@ bool DataStreamReaderBase::seekByIndex(int32_t index) {
   return reader_->seek_by_index(index);
 }
 
-bool DataStreamReaderBase::seekByTimestamp(
-    rcutils_time_point_value_t time) {
+bool DataStreamReaderBase::seekByTimestamp(rcutils_time_point_value_t time) {
   openAndGetMessageType();
   seeked_ = true;
   return reader_->seek_by_timestamp(time);

--- a/vtr_storage/test/read_write_calibration_test.cpp
+++ b/vtr_storage/test/read_write_calibration_test.cpp
@@ -16,6 +16,7 @@
 #include "test_msgs/msg/basic_types.hpp"
 
 namespace fs = std::filesystem;
+using RigCalibration = vtr_messages::msg::RigCalibration;
 
 // sample code showing how to use the data streams
 TEST(VTRStorage, readWriteCalibration) {
@@ -33,7 +34,7 @@ TEST(VTRStorage, readWriteCalibration) {
   }
 
   // attempt to read calibration, should fail
-  vtr::storage::DataStreamReader<TestMsgT> reader(working_dir, stream_name);
+  vtr::storage::DataStreamReader<TestMsgT, RigCalibration> reader(working_dir, stream_name);
   EXPECT_THROW(reader.fetchCalibration(), vtr::storage::NoBagExistsException);
 
   // write a calibration msg
@@ -45,7 +46,7 @@ TEST(VTRStorage, readWriteCalibration) {
   calibration_writer.write(calibration_msg);
 
   // read calibration and data
-  auto calibration = reader.fetchCalibration()->template get<vtr_messages::msg::RigCalibration>();
+  auto calibration = reader.fetchCalibration()->template get<RigCalibration>();
   EXPECT_EQ(calibration, calibration_msg);
 
   auto bag_message_vector = reader.readAtIndexRange(1, 9);
@@ -55,6 +56,11 @@ TEST(VTRStorage, readWriteCalibration) {
     EXPECT_EQ(test_msg.float64_value, count*10);
     ++count;
   }
+
+  // test reading calibration with no calibration type specified
+  // should assert() and crash
+  vtr::storage::DataStreamReader<TestMsgT> reader2(working_dir, stream_name);
+  ASSERT_DEATH(reader2.fetchCalibration(),"");
 }
 
 int main(int argc, char** argv) {

--- a/vtr_storage_examples/src/sample_node_3.cpp
+++ b/vtr_storage_examples/src/sample_node_3.cpp
@@ -8,10 +8,10 @@
 #include "rcutils/time.h"
 
 #include "vtr_logging/logging_init.hpp"
-#include "vtr_storage/message.hpp"
 #include "vtr_storage/data_bubble.hpp"
 #include "vtr_storage/data_stream_reader.hpp"
 #include "vtr_storage/data_stream_writer.hpp"
+#include "vtr_storage/message.hpp"
 
 #include "test_msgs/msg/basic_types.hpp"
 
@@ -42,8 +42,9 @@ int main() {
   auto message = bubble.retrieve(3);  // 3 is local index of this bubble, which
                                       // translates to a global index of 2+3=5
   std::cout << message.template get<TestMsgT>().float64_value << std::endl;
-  bubble.reset(); // ToDo: still fixing the (probably is a) bug where the writer isn't closing properly
-  
+  bubble.reset();  // ToDo: still fixing the (probably is a) bug where the
+                   // writer isn't closing properly
+
   // test_msg.float64_value = reader.readAtIndex(5)->float64_value;
   // std::cout << test_msg.float64_value << std::endl;
 

--- a/vtr_storage_examples/src/sample_node_4.cpp
+++ b/vtr_storage_examples/src/sample_node_4.cpp
@@ -8,10 +8,10 @@
 #include "rcutils/time.h"
 
 #include "vtr_logging/logging_init.hpp"
-#include "vtr_storage/message.hpp"
 #include "vtr_storage/data_bubble.hpp"
 #include "vtr_storage/data_stream_reader.hpp"
 #include "vtr_storage/data_stream_writer.hpp"
+#include "vtr_storage/message.hpp"
 
 #include "test_msgs/msg/basic_types.hpp"
 
@@ -21,13 +21,14 @@ int main() {
   TestMsgT test_msg;
 
   vtr::storage::DataStreamWriter<TestMsgT> writer(
-      "/home/daniel/test/ROS2BagFileParsing/dev_ws/test_rosbag2_writer_api_bag");
+      "/home/daniel/test/ROS2BagFileParsing/dev_ws/"
+      "test_rosbag2_writer_api_bag");
 
   writer.open();
   int64_t timestamp;
   for (int i = 1; i <= 10; i++) {
     test_msg.float64_value = i * 10;
-    timestamp = i*2000;
+    timestamp = i * 2000;
     auto message = vtr::storage::VTRMessage(test_msg);
     message.set_timestamp(timestamp);
     writer.write(message);
@@ -35,9 +36,12 @@ int main() {
   writer.close();
 
   auto reader = std::make_shared<vtr::storage::DataStreamReader<TestMsgT>>(
-      "/home/daniel/test/ROS2BagFileParsing/dev_ws/test_rosbag2_writer_api_bag");
-  test_msg.float64_value = reader->readAtTimestamp(8000)->template get<TestMsgT>().float64_value;
-  std::cout << test_msg.float64_value << std::endl; // should output 40 (vertex 4)
+      "/home/daniel/test/ROS2BagFileParsing/dev_ws/"
+      "test_rosbag2_writer_api_bag");
+  test_msg.float64_value =
+      reader->readAtTimestamp(8000)->template get<TestMsgT>().float64_value;
+  std::cout << test_msg.float64_value
+            << std::endl;  // should output 40 (vertex 4)
 
   std::cout << "~~~~~~~~~~~~~~~~~~~~" << std::endl;
   auto bag_message_vector = reader->readAtTimestampRange(5000, 14500);
@@ -51,7 +55,9 @@ int main() {
       std::static_pointer_cast<vtr::storage::DataStreamReaderBase>(reader));
   bubble.loadTime(8000);
   auto message = bubble.retrieveTime(8000);
-  std::cout << "Message: " << message.template get<TestMsgT>().float64_value << ", index: " << message.get_index() << ", timestamp: " << message.get_timestamp() << std::endl;
+  std::cout << "Message: " << message.template get<TestMsgT>().float64_value
+            << ", index: " << message.get_index()
+            << ", timestamp: " << message.get_timestamp() << std::endl;
 
   std::cout << "~~~~~~~~~~~~~~~~~~~~" << std::endl;
   bubble.unload();
@@ -60,13 +66,17 @@ int main() {
   // bubble.loadTime(5000, 14500);
   for (int time = 6000; time <= 14000; time += 2000) {
     auto message = bubble.retrieveTime(time);
-    std::cout << "Message: " << message.template get<TestMsgT>().float64_value << ", index: " << message.get_index() << ", timestamp: " << message.get_timestamp() << std::endl;
+    std::cout << "Message: " << message.template get<TestMsgT>().float64_value
+              << ", index: " << message.get_index()
+              << ", timestamp: " << message.get_timestamp() << std::endl;
   }
 
   // bubble.setIndices(2, 8);
   // bubble.load();
-  // auto message = bubble.retrieve(3);  // 3 is local index of this bubble, which
-  //                                     // translates to a global index of 2+3=5
+  // auto message = bubble.retrieve(3);  // 3 is local index of this bubble,
+  // which
+  //                                     // translates to a global index of
+  //                                     2+3=5
   // std::cout << message.template get<TestMsgT>().float64_value << std::endl;
 
   // test_msg.float64_value = reader.readAtIndex(5)->float64_value;

--- a/vtr_storage_examples/src/sample_node_5.cpp
+++ b/vtr_storage_examples/src/sample_node_5.cpp
@@ -7,12 +7,12 @@
 #include "rcpputils/filesystem_helper.hpp"
 #include "rcutils/time.h"
 
+#include <vtr_messages/msg/rig_calibration.hpp>
 #include "vtr_logging/logging_init.hpp"
-#include "vtr_storage/message.hpp"
 #include "vtr_storage/data_bubble.hpp"
 #include "vtr_storage/data_stream_reader.hpp"
 #include "vtr_storage/data_stream_writer.hpp"
-#include <vtr_messages/msg/rig_calibration.hpp>
+#include "vtr_storage/message.hpp"
 
 #include "test_msgs/msg/basic_types.hpp"
 
@@ -22,7 +22,8 @@ int main() {
   using RigCalibration = vtr_messages::msg::RigCalibration;
   TestMsgT test_msg;
 
-  std::string base_url = "/home/daniel/test/ROS2BagFileParsing/dev_ws/test_rosbag2_writer_api_bag";
+  std::string base_url =
+      "/home/daniel/test/ROS2BagFileParsing/dev_ws/test_rosbag2_writer_api_bag";
   std::string stream_name = "test_stream";
 
   // write a dummy calibration
@@ -41,17 +42,21 @@ int main() {
   }
 
   // read calibration and data
-  vtr::storage::DataStreamReader<TestMsgT, RigCalibration> reader(base_url, stream_name);
+  vtr::storage::DataStreamReader<TestMsgT, RigCalibration> reader(base_url,
+                                                                  stream_name);
   auto calibration = reader.fetchCalibration()->template get<RigCalibration>();
   for (auto num : calibration.intrinsics[0].k_mat) {
     std::cout << num << std::endl;
   }
   auto bag_message_vector = reader.readAtIndexRange(1, 9);
-  std::cout << "~~~~~~~~~Data~~~~~~~~~~"  << std::endl;
+  std::cout << "~~~~~~~~~Data~~~~~~~~~~" << std::endl;
   for (auto message : *bag_message_vector) {
     std::cout << message->template get<TestMsgT>().float64_value << std::endl;
   }
-  
+
+  std::cout << "~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
+  // THE FOLLOWING SHOULD CRASH: DataStreamReader instantiated with no
+  // calibration type specified, then attempted to fetchCalibration()
   vtr::storage::DataStreamReader<TestMsgT> reader2(base_url, stream_name);
   reader2.fetchCalibration();
 }

--- a/vtr_storage_examples/src/sample_node_5.cpp
+++ b/vtr_storage_examples/src/sample_node_5.cpp
@@ -19,6 +19,7 @@
 // sample code showing how to write/fetch calibration
 int main() {
   using TestMsgT = test_msgs::msg::BasicTypes;
+  using RigCalibration = vtr_messages::msg::RigCalibration;
   TestMsgT test_msg;
 
   std::string base_url = "/home/daniel/test/ROS2BagFileParsing/dev_ws/test_rosbag2_writer_api_bag";
@@ -40,8 +41,8 @@ int main() {
   }
 
   // read calibration and data
-  vtr::storage::DataStreamReader<TestMsgT> reader(base_url, stream_name);
-  auto calibration = reader.fetchCalibration()->template get<vtr_messages::msg::RigCalibration>();
+  vtr::storage::DataStreamReader<TestMsgT, RigCalibration> reader(base_url, stream_name);
+  auto calibration = reader.fetchCalibration()->template get<RigCalibration>();
   for (auto num : calibration.intrinsics[0].k_mat) {
     std::cout << num << std::endl;
   }
@@ -50,4 +51,7 @@ int main() {
   for (auto message : *bag_message_vector) {
     std::cout << message->template get<TestMsgT>().float64_value << std::endl;
   }
+  
+  vtr::storage::DataStreamReader<TestMsgT> reader2(base_url, stream_name);
+  reader2.fetchCalibration();
 }

--- a/vtr_storage_examples/src/sample_node_6.cpp
+++ b/vtr_storage_examples/src/sample_node_6.cpp
@@ -7,12 +7,12 @@
 #include "rcpputils/filesystem_helper.hpp"
 #include "rcutils/time.h"
 
+#include <vtr_messages/msg/rig_calibration.hpp>
 #include "vtr_logging/logging_init.hpp"
-#include "vtr_storage/message.hpp"
 #include "vtr_storage/data_bubble.hpp"
 #include "vtr_storage/data_stream_reader.hpp"
 #include "vtr_storage/data_stream_writer.hpp"
-#include <vtr_messages/msg/rig_calibration.hpp>
+#include "vtr_storage/message.hpp"
 
 #include "test_msgs/msg/basic_types.hpp"
 
@@ -21,7 +21,8 @@ int main() {
   using TestMsgT = test_msgs::msg::BasicTypes;
   TestMsgT test_msg;
 
-  std::string base_url = "/home/daniel/test/ROS2BagFileParsing/dev_ws/test_rosbag2_writer_api_bag";
+  std::string base_url =
+      "/home/daniel/test/ROS2BagFileParsing/dev_ws/test_rosbag2_writer_api_bag";
   std::string stream_name = "test_stream";
 
   // write data
@@ -29,7 +30,7 @@ int main() {
   int32_t timestamp;
   for (int i = 1; i <= 10; i++) {
     test_msg.float64_value = i * 10;
-    timestamp = i*2000;
+    timestamp = i * 2000;
     auto message = vtr::storage::VTRMessage(test_msg);
     message.set_timestamp(timestamp);
     writer.write(message);
@@ -44,7 +45,7 @@ int main() {
   }
 
   // read starting from index 5
-  std::cout << "~~~~~~~~~~~~~~~~~~~"  << std::endl;
+  std::cout << "~~~~~~~~~~~~~~~~~~~" << std::endl;
   reader.seekByIndex(5);
   message = reader.readNextFromSeek();
   while (message.get()) {
@@ -53,12 +54,12 @@ int main() {
   }
 
   // read starting from timestamp 10000
-  std::cout << "~~~~~~~~~~~~~~~~~~~"  << std::endl;
+  std::cout << "~~~~~~~~~~~~~~~~~~~" << std::endl;
   reader.seekByTimestamp(20001);
   message = reader.readNextFromSeek();
   while (message.get()) {
     std::cout << message->template get<TestMsgT>().float64_value << std::endl;
     message = reader.readNextFromSeek();
   }
-  std::cout << "done"  << std::endl;
+  std::cout << "done" << std::endl;
 }


### PR DESCRIPTION
DataStreamReader now takes two template arguments <MessageType, CalibrationType>. CalibrationType is optional, but if it is not specified, attempting to fetchCalibration() would cause an assertion crash.